### PR TITLE
Add drawing tool comment in drawing-simple-example

### DIFF
--- a/docs/tutorial-1-drawing-simple.example.html
+++ b/docs/tutorial-1-drawing-simple.example.html
@@ -736,6 +736,7 @@ var polygon = new naver.maps.Polygon({
 
 var drawingManager;
 naver.maps.Event.once(map, 'init_stylemap', function() {
+    // 그리기 도구 인터페이스 추가 - v3 API URL에 'submodules=drawing' 을 추가해주세요.
     drawingManager = new naver.maps.drawing.DrawingManager({map: map});
     drawingManager.addDrawing(rect, naver.maps.drawing.DrawingMode.RECTANGLE, 'my-id');
     drawingManager.addDrawing(polygon, naver.maps.drawing.DrawingMode.POLYGON);


### PR DESCRIPTION
그리기 도구 인터페이스 사용 안내가 추가되면 어떨까요?
기본 예제를 보고 빠르게 프로토타입을 구현해보고 싶었는데 서브모듈을 URL 에 붙여야하는 건 링크를 많이 타고가야 알게되었습니다.
코드내 주석 위치가 아니더라도 다른 부분에 내용을 추가해보시는 걸 제안드립니다!